### PR TITLE
Move to vercel postgres

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@contentful/rich-text-react-renderer": "^15.16.2",
         "@next/font": "^13.1.1",
-        "@prisma/client": "^4.8.1",
+        "@prisma/client": "^5.11.0",
         "@react-oauth/google": "^0.5.1",
         "@sentry/nextjs": "^7.91.0",
         "@tanstack/react-query": "^4.22.0",
@@ -21,6 +21,7 @@
         "@types/react-scroll": "^1.8.6",
         "@upstash/qstash": "^0.3.4",
         "@vercel/analytics": "^0.1.8",
+        "@vercel/postgres": "^0.7.2",
         "axios": "^1.2.2",
         "contentful": "^9.2.15",
         "contentlayer": "^0.3.3",
@@ -71,7 +72,7 @@
         "contentful-management": "^10.26.0",
         "contentful-typescript-codegen": "^3.4.0",
         "postcss": "^8.4.20",
-        "prisma": "^4.8.1",
+        "prisma": "^5.11.0",
         "tailwindcss": "^3.2.4",
         "ts-node": "^10.9.1"
       }
@@ -970,6 +971,14 @@
         "react": ">=16"
       }
     },
+    "node_modules/@neondatabase/serverless": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@neondatabase/serverless/-/serverless-0.7.2.tgz",
+      "integrity": "sha512-wU3WA2uTyNO7wjPs3Mg0G01jztAxUxzd9/mskMmtPwPTjf7JKWi9AW5/puOGXLxmZ9PVgRFeBVRVYq5nBPhsCg==",
+      "dependencies": {
+        "@types/pg": "8.6.6"
+      }
+    },
     "node_modules/@next/env": {
       "version": "13.1.1",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-13.1.1.tgz",
@@ -1726,15 +1735,12 @@
       }
     },
     "node_modules/@prisma/client": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-4.8.1.tgz",
-      "integrity": "sha512-d4xhZhETmeXK/yZ7K0KcVOzEfI5YKGGEr4F5SBV04/MU4ncN/HcE28sy3e4Yt8UFW0ZuImKFQJE+9rWt9WbGSQ==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-5.11.0.tgz",
+      "integrity": "sha512-SWshvS5FDXvgJKM/a0y9nDC1rqd7KG0Q6ZVzd+U7ZXK5soe73DJxJJgbNBt2GNXOa+ysWB4suTpdK5zfFPhwiw==",
       "hasInstallScript": true,
-      "dependencies": {
-        "@prisma/engines-version": "4.8.0-61.d6e67a83f971b175a593ccc12e15c4a757f93ffe"
-      },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=16.13"
       },
       "peerDependencies": {
         "prisma": "*"
@@ -1745,17 +1751,56 @@
         }
       }
     },
-    "node_modules/@prisma/engines": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-4.8.1.tgz",
-      "integrity": "sha512-93tctjNXcIS+i/e552IO6tqw17sX8liivv8WX9lDMCpEEe3ci+nT9F+1oHtAafqruXLepKF80i/D20Mm+ESlOw==",
-      "devOptional": true,
-      "hasInstallScript": true
+    "node_modules/@prisma/debug": {
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-5.11.0.tgz",
+      "integrity": "sha512-N6yYr3AbQqaiUg+OgjkdPp3KPW1vMTAgtKX6+BiB/qB2i1TjLYCrweKcUjzOoRM5BriA4idrkTej9A9QqTfl3A==",
+      "devOptional": true
     },
-    "node_modules/@prisma/engines-version": {
-      "version": "4.8.0-61.d6e67a83f971b175a593ccc12e15c4a757f93ffe",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-4.8.0-61.d6e67a83f971b175a593ccc12e15c4a757f93ffe.tgz",
-      "integrity": "sha512-MHSOSexomRMom8QN4t7bu87wPPD+pa+hW9+71JnVcF3DqyyO/ycCLhRL1we3EojRpZxKvuyGho2REQsMCvxcJw=="
+    "node_modules/@prisma/engines": {
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-5.11.0.tgz",
+      "integrity": "sha512-gbrpQoBTYWXDRqD+iTYMirDlF9MMlQdxskQXbhARhG6A/uFQjB7DZMYocMQLoiZXO/IskfDOZpPoZE8TBQKtEw==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "@prisma/debug": "5.11.0",
+        "@prisma/engines-version": "5.11.0-15.efd2449663b3d73d637ea1fd226bafbcf45b3102",
+        "@prisma/fetch-engine": "5.11.0",
+        "@prisma/get-platform": "5.11.0"
+      }
+    },
+    "node_modules/@prisma/engines/node_modules/@prisma/engines-version": {
+      "version": "5.11.0-15.efd2449663b3d73d637ea1fd226bafbcf45b3102",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-5.11.0-15.efd2449663b3d73d637ea1fd226bafbcf45b3102.tgz",
+      "integrity": "sha512-WXCuyoymvrS4zLz4wQagSsc3/nE6CHy8znyiMv8RKazKymOMd5o9FP5RGwGHAtgoxd+aB/BWqxuP/Ckfu7/3MA==",
+      "devOptional": true
+    },
+    "node_modules/@prisma/fetch-engine": {
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-5.11.0.tgz",
+      "integrity": "sha512-994viazmHTJ1ymzvWugXod7dZ42T2ROeFuH6zHPcUfp/69+6cl5r9u3NFb6bW8lLdNjwLYEVPeu3hWzxpZeC0w==",
+      "devOptional": true,
+      "dependencies": {
+        "@prisma/debug": "5.11.0",
+        "@prisma/engines-version": "5.11.0-15.efd2449663b3d73d637ea1fd226bafbcf45b3102",
+        "@prisma/get-platform": "5.11.0"
+      }
+    },
+    "node_modules/@prisma/fetch-engine/node_modules/@prisma/engines-version": {
+      "version": "5.11.0-15.efd2449663b3d73d637ea1fd226bafbcf45b3102",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-5.11.0-15.efd2449663b3d73d637ea1fd226bafbcf45b3102.tgz",
+      "integrity": "sha512-WXCuyoymvrS4zLz4wQagSsc3/nE6CHy8znyiMv8RKazKymOMd5o9FP5RGwGHAtgoxd+aB/BWqxuP/Ckfu7/3MA==",
+      "devOptional": true
+    },
+    "node_modules/@prisma/get-platform": {
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-5.11.0.tgz",
+      "integrity": "sha512-rxtHpMLxNTHxqWuGOLzR2QOyQi79rK1u1XYAVLZxDGTLz/A+uoDnjz9veBFlicrpWjwuieM4N6jcnjj/DDoidw==",
+      "devOptional": true,
+      "dependencies": {
+        "@prisma/debug": "5.11.0"
+      }
     },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
@@ -2551,6 +2596,16 @@
       "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-6.0.3.tgz",
       "integrity": "sha512-SuT16Q1K51EAVPz1K29DJ/sXjhSQ0zjvsypYJ6tlwVsRV9jwW5Adq2ch8Dq8kDBCkYnELS7N7VNCSB5nC56t/g=="
     },
+    "node_modules/@types/pg": {
+      "version": "8.6.6",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.6.6.tgz",
+      "integrity": "sha512-O2xNmXebtwVekJDD+02udOncjVcMZQuTEQEMpKJ0ZRf5E7/9JJX3izhKUcUifBkyKpljyUM6BTgy2trmviKlpw==",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
+      }
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.5",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
@@ -2751,6 +2806,20 @@
       "integrity": "sha512-PQrOI8BJ9qUiVJuQfnKiJd15eDjDJH9TBKsNeMrtelT4NAk7d9mBVz1CoZkvoFnHQ0OW7Xnqmr1F2nScfAnznQ==",
       "peerDependencies": {
         "react": "^16.8||^17||^18"
+      }
+    },
+    "node_modules/@vercel/postgres": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@vercel/postgres/-/postgres-0.7.2.tgz",
+      "integrity": "sha512-IqR/ZAvoPGcPaXl9eWWB5KaA+w/81RzZa/18P4izQRHpNBkTGt9HwGfYi9+wut5UgxNq4QSX9A7HIQR6QDvX2Q==",
+      "dependencies": {
+        "@neondatabase/serverless": "0.7.2",
+        "bufferutil": "4.0.8",
+        "utf-8-validate": "6.0.3",
+        "ws": "8.14.2"
+      },
+      "engines": {
+        "node": ">=14.6"
       }
     },
     "node_modules/acorn": {
@@ -3204,6 +3273,18 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+    },
+    "node_modules/bufferutil": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.8.tgz",
+      "integrity": "sha512-4T53u4PdgsXqKaIctwF8ifXlRTTmEPJ8iEPWFdGZvcf7sbwYo6FKFEX9eNNAnzFZ7EzJAQ3CJeOtCRA4rDp7Pw==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
     },
     "node_modules/call-bind": {
       "version": "1.0.2",
@@ -7769,6 +7850,16 @@
         "url": "https://opencollective.com/node-fetch"
       }
     },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.0.tgz",
+      "integrity": "sha512-u6fs2AEUljNho3EYTJNBfImO5QTo/J/1Etd+NVdCj7qWKUSN/bSLkZwhDv7I+w/MSC6qJ4cknepkAYykDdK8og==",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.8.tgz",
@@ -8139,6 +8230,34 @@
         "is-reference": "^3.0.0"
       }
     },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.6.0.tgz",
+      "integrity": "sha512-M+PDm637OY5WM307051+bsDia5Xej6d9IR4GwJse1qA1DIhiKlksvrneZOYQq42OM+spubpcNYEo2FcKQrDk+Q=="
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -8291,6 +8410,41 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true
     },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -8316,20 +8470,19 @@
       }
     },
     "node_modules/prisma": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-4.8.1.tgz",
-      "integrity": "sha512-ZMLnSjwulIeYfaU1O6/LF6PEJzxN5par5weykxMykS9Z6ara/j76JH3Yo2AH3bgJbPN4Z6NeCK9s5fDkzf33cg==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.11.0.tgz",
+      "integrity": "sha512-KCLiug2cs0Je7kGkQBN9jDWoZ90ogE/kvZTUTgz2h94FEo8pczCkPH7fPNXkD1sGU7Yh65risGGD1HQ5DF3r3g==",
       "devOptional": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@prisma/engines": "4.8.1"
+        "@prisma/engines": "5.11.0"
       },
       "bin": {
-        "prisma": "build/index.js",
-        "prisma2": "build/index.js"
+        "prisma": "build/index.js"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=16.13"
       }
     },
     "node_modules/prismjs": {
@@ -10043,6 +10196,18 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
+    "node_modules/utf-8-validate": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-6.0.3.tgz",
+      "integrity": "sha512-uIuGf9TWQ/y+0Lp+KGZCMuJWc3N9BHA+l/UmHd/oUHwJJDeysyTRxNQVkbzsIWfGFbRe3OcgML/i0mvVRPOyDA==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -10276,6 +10441,26 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+    },
+    "node_modules/ws": {
+      "version": "8.14.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
+      "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/xtend": {
       "version": "4.0.2",
@@ -10955,6 +11140,14 @@
         "@types/react": ">=16"
       }
     },
+    "@neondatabase/serverless": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@neondatabase/serverless/-/serverless-0.7.2.tgz",
+      "integrity": "sha512-wU3WA2uTyNO7wjPs3Mg0G01jztAxUxzd9/mskMmtPwPTjf7JKWi9AW5/puOGXLxmZ9PVgRFeBVRVYq5nBPhsCg==",
+      "requires": {
+        "@types/pg": "8.6.6"
+      }
+    },
     "@next/env": {
       "version": "13.1.1",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-13.1.1.tgz",
@@ -11408,23 +11601,64 @@
       }
     },
     "@prisma/client": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-4.8.1.tgz",
-      "integrity": "sha512-d4xhZhETmeXK/yZ7K0KcVOzEfI5YKGGEr4F5SBV04/MU4ncN/HcE28sy3e4Yt8UFW0ZuImKFQJE+9rWt9WbGSQ==",
-      "requires": {
-        "@prisma/engines-version": "4.8.0-61.d6e67a83f971b175a593ccc12e15c4a757f93ffe"
-      }
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-5.11.0.tgz",
+      "integrity": "sha512-SWshvS5FDXvgJKM/a0y9nDC1rqd7KG0Q6ZVzd+U7ZXK5soe73DJxJJgbNBt2GNXOa+ysWB4suTpdK5zfFPhwiw==",
+      "requires": {}
     },
-    "@prisma/engines": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-4.8.1.tgz",
-      "integrity": "sha512-93tctjNXcIS+i/e552IO6tqw17sX8liivv8WX9lDMCpEEe3ci+nT9F+1oHtAafqruXLepKF80i/D20Mm+ESlOw==",
+    "@prisma/debug": {
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-5.11.0.tgz",
+      "integrity": "sha512-N6yYr3AbQqaiUg+OgjkdPp3KPW1vMTAgtKX6+BiB/qB2i1TjLYCrweKcUjzOoRM5BriA4idrkTej9A9QqTfl3A==",
       "devOptional": true
     },
-    "@prisma/engines-version": {
-      "version": "4.8.0-61.d6e67a83f971b175a593ccc12e15c4a757f93ffe",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-4.8.0-61.d6e67a83f971b175a593ccc12e15c4a757f93ffe.tgz",
-      "integrity": "sha512-MHSOSexomRMom8QN4t7bu87wPPD+pa+hW9+71JnVcF3DqyyO/ycCLhRL1we3EojRpZxKvuyGho2REQsMCvxcJw=="
+    "@prisma/engines": {
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-5.11.0.tgz",
+      "integrity": "sha512-gbrpQoBTYWXDRqD+iTYMirDlF9MMlQdxskQXbhARhG6A/uFQjB7DZMYocMQLoiZXO/IskfDOZpPoZE8TBQKtEw==",
+      "devOptional": true,
+      "requires": {
+        "@prisma/debug": "5.11.0",
+        "@prisma/engines-version": "5.11.0-15.efd2449663b3d73d637ea1fd226bafbcf45b3102",
+        "@prisma/fetch-engine": "5.11.0",
+        "@prisma/get-platform": "5.11.0"
+      },
+      "dependencies": {
+        "@prisma/engines-version": {
+          "version": "5.11.0-15.efd2449663b3d73d637ea1fd226bafbcf45b3102",
+          "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-5.11.0-15.efd2449663b3d73d637ea1fd226bafbcf45b3102.tgz",
+          "integrity": "sha512-WXCuyoymvrS4zLz4wQagSsc3/nE6CHy8znyiMv8RKazKymOMd5o9FP5RGwGHAtgoxd+aB/BWqxuP/Ckfu7/3MA==",
+          "devOptional": true
+        }
+      }
+    },
+    "@prisma/fetch-engine": {
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-5.11.0.tgz",
+      "integrity": "sha512-994viazmHTJ1ymzvWugXod7dZ42T2ROeFuH6zHPcUfp/69+6cl5r9u3NFb6bW8lLdNjwLYEVPeu3hWzxpZeC0w==",
+      "devOptional": true,
+      "requires": {
+        "@prisma/debug": "5.11.0",
+        "@prisma/engines-version": "5.11.0-15.efd2449663b3d73d637ea1fd226bafbcf45b3102",
+        "@prisma/get-platform": "5.11.0"
+      },
+      "dependencies": {
+        "@prisma/engines-version": {
+          "version": "5.11.0-15.efd2449663b3d73d637ea1fd226bafbcf45b3102",
+          "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-5.11.0-15.efd2449663b3d73d637ea1fd226bafbcf45b3102.tgz",
+          "integrity": "sha512-WXCuyoymvrS4zLz4wQagSsc3/nE6CHy8znyiMv8RKazKymOMd5o9FP5RGwGHAtgoxd+aB/BWqxuP/Ckfu7/3MA==",
+          "devOptional": true
+        }
+      }
+    },
+    "@prisma/get-platform": {
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-5.11.0.tgz",
+      "integrity": "sha512-rxtHpMLxNTHxqWuGOLzR2QOyQi79rK1u1XYAVLZxDGTLz/A+uoDnjz9veBFlicrpWjwuieM4N6jcnjj/DDoidw==",
+      "devOptional": true,
+      "requires": {
+        "@prisma/debug": "5.11.0"
+      }
     },
     "@protobufjs/aspromise": {
       "version": "1.1.2",
@@ -12079,6 +12313,16 @@
       "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-6.0.3.tgz",
       "integrity": "sha512-SuT16Q1K51EAVPz1K29DJ/sXjhSQ0zjvsypYJ6tlwVsRV9jwW5Adq2ch8Dq8kDBCkYnELS7N7VNCSB5nC56t/g=="
     },
+    "@types/pg": {
+      "version": "8.6.6",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.6.6.tgz",
+      "integrity": "sha512-O2xNmXebtwVekJDD+02udOncjVcMZQuTEQEMpKJ0ZRf5E7/9JJX3izhKUcUifBkyKpljyUM6BTgy2trmviKlpw==",
+      "requires": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
+      }
+    },
     "@types/prop-types": {
       "version": "15.7.5",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
@@ -12230,6 +12474,17 @@
       "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-0.1.8.tgz",
       "integrity": "sha512-PQrOI8BJ9qUiVJuQfnKiJd15eDjDJH9TBKsNeMrtelT4NAk7d9mBVz1CoZkvoFnHQ0OW7Xnqmr1F2nScfAnznQ==",
       "requires": {}
+    },
+    "@vercel/postgres": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@vercel/postgres/-/postgres-0.7.2.tgz",
+      "integrity": "sha512-IqR/ZAvoPGcPaXl9eWWB5KaA+w/81RzZa/18P4izQRHpNBkTGt9HwGfYi9+wut5UgxNq4QSX9A7HIQR6QDvX2Q==",
+      "requires": {
+        "@neondatabase/serverless": "0.7.2",
+        "bufferutil": "4.0.8",
+        "utf-8-validate": "6.0.3",
+        "ws": "8.14.2"
+      }
     },
     "acorn": {
       "version": "8.8.1",
@@ -12533,6 +12788,14 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+    },
+    "bufferutil": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.8.tgz",
+      "integrity": "sha512-4T53u4PdgsXqKaIctwF8ifXlRTTmEPJ8iEPWFdGZvcf7sbwYo6FKFEX9eNNAnzFZ7EzJAQ3CJeOtCRA4rDp7Pw==",
+      "requires": {
+        "node-gyp-build": "^4.3.0"
+      }
     },
     "call-bind": {
       "version": "1.0.2",
@@ -15688,6 +15951,11 @@
         "formdata-polyfill": "^4.0.10"
       }
     },
+    "node-gyp-build": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.0.tgz",
+      "integrity": "sha512-u6fs2AEUljNho3EYTJNBfImO5QTo/J/1Etd+NVdCj7qWKUSN/bSLkZwhDv7I+w/MSC6qJ4cknepkAYykDdK8og=="
+    },
     "node-releases": {
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.8.tgz",
@@ -15950,6 +16218,28 @@
         "is-reference": "^3.0.0"
       }
     },
+    "pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="
+    },
+    "pg-protocol": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.6.0.tgz",
+      "integrity": "sha512-M+PDm637OY5WM307051+bsDia5Xej6d9IR4GwJse1qA1DIhiKlksvrneZOYQq42OM+spubpcNYEo2FcKQrDk+Q=="
+    },
+    "pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "requires": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      }
+    },
     "picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -16032,6 +16322,29 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true
     },
+    "postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="
+    },
+    "postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w=="
+    },
+    "postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q=="
+    },
+    "postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "requires": {
+        "xtend": "^4.0.0"
+      }
+    },
     "prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -16045,12 +16358,12 @@
       "peer": true
     },
     "prisma": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-4.8.1.tgz",
-      "integrity": "sha512-ZMLnSjwulIeYfaU1O6/LF6PEJzxN5par5weykxMykS9Z6ara/j76JH3Yo2AH3bgJbPN4Z6NeCK9s5fDkzf33cg==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.11.0.tgz",
+      "integrity": "sha512-KCLiug2cs0Je7kGkQBN9jDWoZ90ogE/kvZTUTgz2h94FEo8pczCkPH7fPNXkD1sGU7Yh65risGGD1HQ5DF3r3g==",
       "devOptional": true,
       "requires": {
-        "@prisma/engines": "4.8.1"
+        "@prisma/engines": "5.11.0"
       }
     },
     "prismjs": {
@@ -17278,6 +17591,14 @@
       "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
       "requires": {}
     },
+    "utf-8-validate": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-6.0.3.tgz",
+      "integrity": "sha512-uIuGf9TWQ/y+0Lp+KGZCMuJWc3N9BHA+l/UmHd/oUHwJJDeysyTRxNQVkbzsIWfGFbRe3OcgML/i0mvVRPOyDA==",
+      "requires": {
+        "node-gyp-build": "^4.3.0"
+      }
+    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -17457,6 +17778,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+    },
+    "ws": {
+      "version": "8.14.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
+      "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
+      "requires": {}
     },
     "xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -8,14 +8,14 @@
     "start": "next start",
     "lint": "next lint",
     "codegen": "contentful-typescript-codegen --output @types/generated/contentful.d.ts",
-    "push": "npx prisma db push",
-    "gen": "npx prisma generate",
-    "cache-clear": "./node_modules/.bin/contentlayer build --verbose --clearCache"
+    "db": "npx prisma db push; npx prisma generate",
+    "cache-clear": "./node_modules/.bin/contentlayer build --verbose --clearCache",
+    "vercel-build": "prisma generate && prisma migrate deploy && next build"
   },
   "dependencies": {
     "@contentful/rich-text-react-renderer": "^15.16.2",
     "@next/font": "^13.1.1",
-    "@prisma/client": "^4.8.1",
+    "@prisma/client": "^5.11.0",
     "@react-oauth/google": "^0.5.1",
     "@sentry/nextjs": "^7.91.0",
     "@tanstack/react-query": "^4.22.0",
@@ -26,6 +26,7 @@
     "@types/react-scroll": "^1.8.6",
     "@upstash/qstash": "^0.3.4",
     "@vercel/analytics": "^0.1.8",
+    "@vercel/postgres": "^0.7.2",
     "axios": "^1.2.2",
     "contentful": "^9.2.15",
     "contentlayer": "^0.3.3",
@@ -76,7 +77,7 @@
     "contentful-management": "^10.26.0",
     "contentful-typescript-codegen": "^3.4.0",
     "postcss": "^8.4.20",
-    "prisma": "^4.8.1",
+    "prisma": "^5.11.0",
     "tailwindcss": "^3.2.4",
     "ts-node": "^10.9.1"
   }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -12,8 +12,6 @@ import {
 import Entries from "../components/Entries/entries";
 import PhotoCollection from "../components/PhotoCollection/photoCollection";
 import Helmet from "../components/Navigation/Helmet";
-import Banner from "../components/Banner/Banner";
-import { useQueryClient } from "@tanstack/react-query";
 import Navigation from "../components/Navigation/Navigation";
 export async function getStaticProps() {
   const cEntries = await getContentfulEntries("entries");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -3,7 +3,7 @@
 
 datasource db {
   provider = "postgresql"
-  url      = env("DATABASE_URL")
+  url      = env("POSTGRES_PRISMA_URL")
 }
 
 generator client {


### PR DESCRIPTION
ElephantSQL is shutting down. Moving to Vercel Postgres seems like the most logical option given the site itself is hosted on Vercel. The db region is Sydney, and its free... for now.