### PR TITLE
Adjust image cache TTL to reduce number of image cache reads

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -10,6 +10,7 @@ const nextConfig = {
       "lh3.googleusercontent.com",
       "static.productionready.io",
     ],
+    minimumCacheTTL: 2678400, // 31 days
   },
 };
 


### PR DESCRIPTION
Fixes a potential issue of my image cache reads exceeding the number allowed with the free Vercel tier.
Images on the site do not change very often so they only need to be refreshed monthly.

https://vercel.com/docs/image-optimization/managing-image-optimization-costs