### PR TITLE
Remove API call for banner entries

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,15 +1,15 @@
-import { IBanner, IEntries, IPhotoCollection, IThumbnail } from "../@types/generated/contentful";
+import { IEntries, IPhotoCollection, IThumbnail } from "../@types/generated/contentful";
 import { getContentfulEntries, seedContentfulRecords } from "../lib/api/contentful";
 import Records from "../components/Records/records";
 import Entries from "../components/Entries/entries";
 import PhotoCollection from "../components/PhotoCollection/photoCollection";
 import Helmet from "../components/Navigation/Helmet";
 import Navigation from "../components/Navigation/Navigation";
+
 export async function getStaticProps() {
   const cEntries = await getContentfulEntries("entries");
   const cRecords = await getContentfulEntries("thumbnail");
   const cPhotos = await getContentfulEntries("photoCollection");
-  const cBanner = await getContentfulEntries("banner");
 
   if (process.env.NODE_ENV === "production") {
     await seedContentfulRecords(cRecords.items as IThumbnail[]);
@@ -20,7 +20,6 @@ export async function getStaticProps() {
       entries: cEntries.items,
       records: cRecords.items,
       photos: cPhotos.items,
-      banner: cBanner.items[0],
     },
   };
 }
@@ -29,19 +28,15 @@ export default function Home({
   entries,
   records,
   photos,
-  banner,
 }: {
   entries: IEntries[];
   records: IThumbnail[];
   photos: IPhotoCollection[];
-  banner: IBanner;
 }) {
   return (
     <>
       <Helmet title="Home" />
       <Navigation color="black" />
-      {/* <Banner banner={banner} /> */}
-
       <Records records={records} />
       <PhotoCollection photos={photos} />
       {/* <Entries entries={entries} /> */}


### PR DESCRIPTION
Fixes the deployment by removing the API call for banner entries which I have just removed from Contentful as part of a cleanup.